### PR TITLE
Specifying jenkins_api_client gem version that is available

### DIFF
--- a/foreman_pipeline.gemspec
+++ b/foreman_pipeline.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency "bastion", "~> 2.0"
   s.add_dependency "net-ssh", "<= 2.9.2"
   s.add_dependency "net-scp", "~> 1.2"
-  s.add_dependency "jenkins_api_client", "~> 1.4"
+  s.add_dependency "jenkins_api_client", "~> 1.4.0"
 end


### PR DESCRIPTION
Bundler has problems finding the specified jenkins_api_client gem version. This aims to take care of the problem.
