### PR TITLE
Use Travis for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+sudo: required
+services:
+  - docker
+env:
+  - RUBY=2.0
+  - RUBY=2.1
+  - RUBY=2.2
+before_install:
+  - sudo docker pull oprazak/centos7:ruby_test2
+  - sudo docker pull postgres
+install:
+ - ./shell/travis_install.sh
+script:
+  - ./shell/travis_script.sh

--- a/lib/foreman_pipeline/tasks/foreman_pipeline_test.rake
+++ b/lib/foreman_pipeline/tasks/foreman_pipeline_test.rake
@@ -1,13 +1,13 @@
 require File.expand_path("../engine", File.dirname(__FILE__))
 
 namespace :test do
-
+  desc "Run plugin test suite"
   task :foreman_pipeline => ['db:test:prepare'] do
     test_task = Rake::TestTask.new('foreman_pipeline_test_task') do |t|
       t.libs << ["test", "#{ForemanPipeline::Engine.root}/test"]
       t.test_files = ["#{ForemanPipeline::Engine.root}/test/**/*_test.rb"]
       t.warning = false
-      t.verbose = false
+      t.verbose = true
     end
     Rake::Task[test_task.name].invoke
   end

--- a/shell/travis_install.sh
+++ b/shell/travis_install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+cd ..
+mkdir projects
+cp -r foreman_pipeline projects
+cd projects
+
+git clone https://github.com/theforeman/foreman.git
+git clone https://github.com/katello/katello.git
+
+echo "gemspec :path => '../katello', :development_group => :katello_dev" >> foreman/bundler.d/Gemfile.local.rb
+echo "gemspec :path => '../foreman_pipeline'" >> foreman/bundler.d/Gemfile.local.rb
+
+cat > foreman/config/database.yml << EOF
+test:
+  adapter: postgresql
+  database: foreman
+  username: postgres
+  host: postgresql
+development:
+  adapter: postgresql
+  database: foreman
+  username: postgres
+  host: postgresql
+EOF
+
+cat > foreman/config/settings.yaml << EOF
+:unattended: true
+:login: true
+:require_ssl: false
+:locations_enabled: true
+:organizations_enabled: true
+EOF
+
+cat foreman/bundler.d/Gemfile.local.rb
+cat foreman/config/database.yml
+cat foreman/config/settings.yml
+cd ..
+chmod -R o+w projects

--- a/shell/travis_script.sh
+++ b/shell/travis_script.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+cd ..
+docker run --name postgresql -d postgres
+docker run -d --link postgresql:postgresql --name cos -v $(pwd)/projects:/projects oprazak/centos7:ruby_test2 tail -f /dev/null
+
+docker exec cos su - user -c "rvm install ${RUBY}"
+docker exec cos su - user -c "gem install bundler"
+
+docker exec cos su - user -c "(cd /projects/foreman && bundle install)"
+docker exec cos su - user -c "((cd /projects/foreman && bundle exec rake db:create && bundle exec rake db:migrate && bundle exec rake test:foreman_pipeline) || exit 1)"


### PR DESCRIPTION
test_plugin_pull_request job on our Jenkins is not yet
in foreman-infra, which is kind of a dead end for me.
I need to remove mysql from test_plugin_matrix because
katello does not support it and there are crashes during
migrations (indexes too long). It can be easily
done with dynamic axis plugin for Jenkins
once the job is in yml file. I decided to run
the tests on Travis to move forward,
which will also allow me greater controll over the process.

Additional complication is possibly broken package
for qpidd on debian. I am not sure what is going on,
but qpid_messaging gem just won't install due to some
missing file in native extensions. So I run the tests
in CentOS 7 container, which is obviously not ideal.
On the other hand, the tests are running.
